### PR TITLE
add pipeline example notebook

### DIFF
--- a/run/6-Pipeline/submit-pipeline.ipynb
+++ b/run/6-Pipeline/submit-pipeline.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running a serial pipeline on DLHub\n",
+    "\n",
+    "\n",
+    "DLHub supports users to chain a serial of servables, where the output of a servable is passed to the next servable as its input. This notebook shows an example on how one can run a serial pipeline on DLHub. In this notebook, we will use the \"Increment\" servable, which increments the input by \"1\" each time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dlhub_sdk.client import DLHubClient\n",
+    "\n",
+    "dl = DLHubClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Search the Increment servable, which increments the input by 1 when invoked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'datacite': {'alternateIdentifiers': [], 'creators': [{'affiliations': 'University of Chicago', 'familyName': 'Li', 'givenName': 'Zhuozhao'}], 'descriptions': [{'description': 'An increment function for testing.', 'descriptionType': 'Abstract'}], 'fundingReferences': [], 'identifier': {'identifier': '10.YET/UNASSIGNED', 'identifierType': 'DOI'}, 'publicationYear': '2020', 'publisher': 'DLHub', 'relatedIdentifiers': [{'relatedIdentifier': 'globus:8J5Hxy9HMKqD', 'relatedIdentifierType': 'Globus', 'relationType': 'IsDescribedBy'}], 'resourceType': {'resourceTypeGeneral': 'InteractiveResource'}, 'rightsList': [], 'titles': [{'title': 'DLHub increment Function'}]}, 'dlhub': {'build_location': '/mnt/dlhub_ingest/8cabf7d9-0d6b-4967-8d54-ab4fb0252d9a-1598303659', 'domains': ['general', 'test'], 'ecr_arn': 'arn:aws:ecr:us-east-1:039706667969:repository/8cabf7d9-0d6b-4967-8d54-ab4fb0252d9a', 'ecr_uri': '039706667969.dkr.ecr.us-east-1.amazonaws.com/8cabf7d9-0d6b-4967-8d54-ab4fb0252d9a', 'files': {'other': ['increment.py']}, 'funcx_id': '3c4c38a5-8d8e-483a-9ee4-68bbac752d6b', 'id': '8cabf7d9-0d6b-4967-8d54-ab4fb0252d9a', 'identifier': 'globus:8J5Hxy9HMKqD', 'name': 'Increment', 'owner': 'zhuozhao_uchicago', 'publication_date': '1598303658999', 'shorthand_name': 'zhuozhao_uchicago/Increment', 'test': False, 'transfer_method': {'POST': 'file', 'path': '/mnt/tmp/servable.zip'}, 'type': 'servable', 'user_id': '10', 'version': '0.8.4', 'visible_to': ['public']}, 'servable': {'methods': {'run': {'input': {'description': 'integer or float', 'type': 'number'}, 'method_details': {'autobatch': False, 'method_name': 'increment', 'module': 'increment'}, 'output': {'description': 'increment the input data by 1', 'type': 'number'}, 'parameters': {}}}, 'shim': 'python.PythonStaticMethodServable', 'type': 'Python static method'}}]\n",
+      "zhuozhao_uchicago/Increment\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_serv = dl.search_by_servable(servable_name=\"Increment\")\n",
+    "print(df_serv)\n",
+    "servable_name = df_serv[0]['dlhub']['shorthand_name']\n",
+    "print(servable_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Chain the the Increment servable three times in serial as a list. \n",
+    "\n",
+    "Note: You can chain as many as you want, and also chain any other servables in the series, as long as the output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = dl.run_serial([servable_name, servable_name, servable_name], 10)\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call the the Increment servable twice in serial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = dl.run_serial([servable_name, servable_name], 3.5)\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (dlhub-htex)",
+   "language": "python",
+   "name": "dlhub-htex"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a notebook for running pipeline on DLHub. It simply chains three `Increment` servable in this example.